### PR TITLE
Improve error message of java command such as "SyntaxError: Unexpecte…

### DIFF
--- a/src/validate.coffee
+++ b/src/validate.coffee
@@ -9,17 +9,16 @@ module.exports = (input, xargs={}, args={}, vnuPath=helper.vnuJar) ->
     helper.genArgs(args),
     "-"
   )
-  result = []
+  result = ""
   try
     validator = spawn helper.javaBin(), argsToPass
     validator.stderr.on "data", (data) ->
-      result.push data
+      result += data
     validator.stderr.on "end", ->
-      result = result.join("")
       try
         defer.resolve JSON.parse(result).messages
       catch e
-        e.message += "\n" + result
+        e.message += "\n#{result}"
         defer.reject e
     validator.stdin.write input
     validator.stdin.end()

--- a/src/validate.coffee
+++ b/src/validate.coffee
@@ -15,7 +15,12 @@ module.exports = (input, xargs={}, args={}, vnuPath=helper.vnuJar) ->
     validator.stderr.on "data", (data) ->
       result.push data
     validator.stderr.on "end", ->
-      defer.resolve JSON.parse(result.join("")).messages
+      result = result.join("")
+      try
+        defer.resolve JSON.parse(result).messages
+      catch e
+        e.message += "\n" + result
+        defer.reject e
     validator.stdin.write input
     validator.stdin.end()
   catch e

--- a/src/validateFiles.coffee
+++ b/src/validateFiles.coffee
@@ -9,17 +9,16 @@ module.exports = (files, xargs={}, args={}, vnuPath=helper.vnuJar) ->
     files
   )
   defer = require("q").defer()
-  result = []
+  result = ""
   try
     validator = spawn helper.javaBin(), argsToPass
     validator.stderr.on "data", (data) ->
-      result.push data
+      result += data
     validator.stderr.on "end", ->
-      result = result.join("")
       try
         defer.resolve JSON.parse(result).messages
       catch e
-        e.message += "\n" + result
+        e.message += "\n#{result}"
         defer.reject e
   catch e
     defer.reject e

--- a/src/validateFiles.coffee
+++ b/src/validateFiles.coffee
@@ -9,13 +9,17 @@ module.exports = (files, xargs={}, args={}, vnuPath=helper.vnuJar) ->
     files
   )
   defer = require("q").defer()
-
+  result = []
   try
     validator = spawn helper.javaBin(), argsToPass
     validator.stderr.on "data", (data) ->
+      result.push data
+    validator.stderr.on "end", ->
+      result = result.join("")
       try
-        defer.resolve JSON.parse(data).messages
+        defer.resolve JSON.parse(result).messages
       catch e
+        e.message += "\n" + result
         defer.reject e
   catch e
     defer.reject e

--- a/tests/spec/invalid.coffee
+++ b/tests/spec/invalid.coffee
@@ -91,18 +91,20 @@ describe "Invalid case tests", ->
       ).done (-> done()), done
 
 describe "Print Java error message", ->
-  it "The message should be printed when `validate()` called", ->
-    vnu.validate("<html/>", ("ss": "64"))
-      .catch (err) ->
-        expect(err).to.be.an.instanceof(SyntaxError)
-        expect(err.message).to.match(
-          /^Unexpected token [\s\S]+Invalid thread stack size: -Xss64/
-        )
+  describe "When `validate()` is called", ->
+    it "The message should be printed", ->
+      vnu.validate("<html/>", ("ss": "64"))
+        .catch (err) ->
+          expect(err).to.be.an.instanceof(SyntaxError)
+          expect(err.message).to.match(
+            /^Unexpected token [\s\S]+Invalid thread stack size: -Xss64/
+          )
 
-  it "The message should be printed when `validateFiles()` called", ->
-    vnu.validateFiles(["./tests/data/invalid.html"], ("ss": "32"))
-      .catch (err) ->
-        expect(err).to.be.an.instanceof(SyntaxError)
-        expect(err.message).to.match(
-          /^Unexpected token [\s\S]+Invalid thread stack size: -Xss32/
-        )
+  describe "When `validateFiles()` is called", ->
+    it "The message should be printed", ->
+      vnu.validateFiles(["./tests/data/invalid.html"], ("ss": "32"))
+        .catch (err) ->
+          expect(err).to.be.an.instanceof(SyntaxError)
+          expect(err.message).to.match(
+            /^Unexpected token [\s\S]+Invalid thread stack size: -Xss32/
+          )

--- a/tests/spec/invalid.coffee
+++ b/tests/spec/invalid.coffee
@@ -91,22 +91,18 @@ describe "Invalid case tests", ->
       ).done (-> done()), done
 
 describe "Print Java error message", ->
-  it "when `validate()` called", (done) ->
+  it "The message should be printed when `validate()` called", ->
     vnu.validate("<html/>", ("ss": "64"))
       .catch (err) ->
         expect(err).to.be.an.instanceof(SyntaxError)
         expect(err.message).to.match(
-          /^Unexpected token I\nInvalid thread stack size: -Xss64\n/
+          /^Unexpected token [\s\S]+Invalid thread stack size: -Xss64/
         )
-        done()
-      .done (-> ;), done
 
-  it "when `validateFiles()` called", (done) ->
+  it "The message should be printed when `validateFiles()` called", ->
     vnu.validateFiles(["./tests/data/invalid.html"], ("ss": "32"))
       .catch (err) ->
         expect(err).to.be.an.instanceof(SyntaxError)
         expect(err.message).to.match(
-          /^Unexpected token I\nInvalid thread stack size: -Xss32\n/
+          /^Unexpected token [\s\S]+Invalid thread stack size: -Xss32/
         )
-        done()
-      .done (-> ;), done

--- a/tests/spec/invalid.coffee
+++ b/tests/spec/invalid.coffee
@@ -89,3 +89,24 @@ describe "Invalid case tests", ->
       ]).then(cb).catch(
         (err) -> throw err
       ).done (-> done()), done
+
+describe "Print Java error message", ->
+  it "when `validate()` called", (done) ->
+    vnu.validate("<html/>", ("ss": "64"))
+      .catch (err) ->
+        expect(err).to.be.an.instanceof(SyntaxError)
+        expect(err.message).to.match(
+          /^Unexpected token I\nInvalid thread stack size: -Xss64\n/
+        )
+        done()
+      .done (-> ;), done
+
+  it "when `validateFiles()` called", (done) ->
+    vnu.validateFiles(["./tests/data/invalid.html"], ("ss": "32"))
+      .catch (err) ->
+        expect(err).to.be.an.instanceof(SyntaxError)
+        expect(err.message).to.match(
+          /^Unexpected token I\nInvalid thread stack size: -Xss32\n/
+        )
+        done()
+      .done (-> ;), done


### PR DESCRIPTION
…d token E".

Reproduction:
1. Update **vnu.jar** to latest version. (Download from https://github.com/validator/validator/)
2. Set JAVA_HOME to Java 7.
3. Run shell command:
```
node -e "require('validator-nu').validate('')"
```

Console output:
```
undefined:1
Exception in thread "main" java.lang.UnsupportedClassVersionError: nu/validator/client/SimpleCommandLineValidator : Unsupported major.minor version 52.0
^

SyntaxError: Unexpected token E
    at Object.parse (native)
    at Socket.<anonymous> (/tmp/foo/node_modules/validator-nu/lib/validate.js:30:35)
    at emitNone (events.js:72:20)
    at Socket.emit (events.js:166:7)
    at endReadableNT (_stream_readable.js:905:12)
    at nextTickCallbackWith2Args (node.js:441:9)
    at process._tickCallback (node.js:355:17)
```