### PR TITLE
Make vnu-jar a non-dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "dargs": "^5.1.0",
     "freeport": "^1.0.5",
-    "q": "^1.4.1"
+    "q": "^1.4.1",
+    "vnu-jar": "^16.6.29"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -27,8 +28,7 @@
     "gulp-coffeelint": "^0.6.0",
     "gulp-mocha": "^3.0.1",
     "gulp-sourcemaps": "^2.2.0",
-    "mocha": "^3.2.0",
-    "vnu-jar": "^16.6.29"
+    "mocha": "^3.2.0"
   },
   "scripts": {
     "compile": "./node_modules/gulp/bin/gulp.js compile",


### PR DESCRIPTION
The vnu jar file is required for production use, so it should be a hard dependency.

(If you ever feel like making this dependency the responsibility of the caller, then that would be a major breaking change and as such would require a semver major version bump. I can see no reason to put such a burden on the caller.)